### PR TITLE
make it easier for spec readers to determine that Function.prototype.toString always returns a String

### DIFF
--- a/proposal.html
+++ b/proposal.html
@@ -535,7 +535,7 @@ toc: true
   <ins class="block">
     <emu-alg>
       1. If _func_ is a <emu-xref href="#sec-bound-function-exotic-objects">Bound Function exotic object</emu-xref> or a <emu-xref href="#sec-ecmascript-standard-built-in-objects">built-in Function object</emu-xref>, then return an implementation-dependent String source code representation of _func_. The representation must have the syntax of a |NativeFunction|. Additionally, if _func_ is a <emu-xref href="#sec-well-known-intrinsic-objects">Well-known Intrinsic Object</emu-xref>, the portion of the returned String that would be matched by |BindingIdentifier| must be the initial value of the *name* property of _func_.
-      1. If _func_ has a [[SourceText]] internal slot and _func_.[[SourceText]] is not *undefined*
+      1. If _func_ has a [[SourceText]] internal slot and Type(_func_.[[SourceText]]) is String
         1. Let _sourceText_ be _func_.[[SourceText]].
         1. Let _sourceText_ be _sourceText_ with all occurrences of the code unit sequence 0x000D (CARRIAGE RETURN) 0x000A (LINE FEED) replaced with the single code unit 0x000A (LINE FEED).
         1. Let _sourceText_ be _sourceText_ with all occurrences of the code unit 0x000D (CARRIAGE RETURN) replaced with 0x000A (LINE FEED).


### PR DESCRIPTION
(when it does not throw)

Additionally, the proper way to have done the negative check would be to use `is not empty`.
