### PR TITLE
fixes #19: remove line terminator normalisation

### DIFF
--- a/proposal.html
+++ b/proposal.html
@@ -528,11 +528,7 @@ toc: true
   <ins class="block">
     <emu-alg>
       1. If _func_ is a <emu-xref href="#sec-bound-function-exotic-objects">Bound Function exotic object</emu-xref> or a <emu-xref href="#sec-ecmascript-standard-built-in-objects">built-in Function object</emu-xref>, then return an implementation-dependent String source code representation of _func_. The representation must have the syntax of a |NativeFunction|. Additionally, if _func_ is a <emu-xref href="#sec-well-known-intrinsic-objects">Well-known Intrinsic Object</emu-xref>, the portion of the returned String that would be matched by |IdentifierName| must be the initial value of the *name* property of _func_.
-      1. If _func_ has a [[SourceText]] internal slot and Type(_func_.[[SourceText]]) is String
-        1. Let _sourceText_ be _func_.[[SourceText]].
-        1. Let _sourceText_ be _sourceText_ with all occurrences of the code unit sequence 0x000D (CARRIAGE RETURN) 0x000A (LINE FEED) replaced with the single code unit 0x000A (LINE FEED).
-        1. Let _sourceText_ be _sourceText_ with all occurrences of the code unit 0x000D (CARRIAGE RETURN) replaced with 0x000A (LINE FEED).
-        1. Return _sourceText_.
+      1. If _func_ has a [[SourceText]] internal slot and Type(_func_.[[SourceText]]) is String, then return _func_.[[SourceText]].
       1. If Type(_func_) is Object and IsCallable(_func_) is *true*, then return an implementation-dependent String source code representation of _func_. The representation must have the syntax of a |NativeFunction|.
       1. Throw a *TypeError* exception.
     </emu-alg>


### PR DESCRIPTION
Fixes #19. Implementors have made it clear that they do not plan to implement `Function.prototype.toString` line terminator normalisation due to either performance costs or extreme difficulty in preserving performance. Line terminator normalisation is a feature of `Function.prototype.toString` that never existed in reality. It was added mostly for consistency with templates and to avoid accidentally observing file encodings. But we are not trying to design a nice API. We are trying to document a legacy feature of JavaScript that would be more appropriate in Annex B. Because of this, we will make it easy for implementors to follow the spec with as few changes to their implementation as possible. The goal of this proposal is to simply further specify the `Function.prototype.toString` behaviour and align implementations where they deviate from each other.